### PR TITLE
Contract watcher now correctly tracks individual file changes in output folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
-## [0.0.18] - 2024
+## [0.0.19] - 18.04.2025
+
+### Fixed
+- Contract watcher now correctly tracks individual file changes in output folder
+
+## [0.0.18] - 17.04.2025
 
 ### Fixed
 - Coverage report compatibility with new Medusa report format
 - Issue with fuzzer not stopping
 
+[0.0.19]: https://github.com/Recon-Fuzz/recon-extension/releases/tag/v0.0.19
 [0.0.18]: https://github.com/Recon-Fuzz/recon-extension/releases/tag/v0.0.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.0.19] - 18.04.2025
+## [0.0.19] - 17.04.2025
 
 ### Fixed
 - Contract watcher now correctly tracks individual file changes in output folder

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "recon",
   "displayName": "Recon",
   "description": "Seamless integration of Foundry, Medusa, and Echidna for smart contract testing",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "license": "gpl-2.0",
   "publisher": "Recon-Fuzz",
   "repository": {

--- a/src/commands/mockCommands.ts
+++ b/src/commands/mockCommands.ts
@@ -72,6 +72,7 @@ export function registerMockCommands(
                     );
 
                     vscode.window.showInformationMessage(`Generated mock contract: ${mockName}`);
+                    vscode.window.showInformationMessage(`Please build the project to see the generated mock in the contracts explorer.`);
 
                     // Open the generated mock file
                     const mockPath = vscode.Uri.file(mockFilePath);

--- a/src/reconContractsView.ts
+++ b/src/reconContractsView.ts
@@ -1300,15 +1300,6 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
         return this.getMutableFunctions(contract.abi).length > 0;
     }
 
-    private areAllContractsSelected(): boolean {
-        const visibleContracts = this.contracts.filter(
-            contract =>
-                this.hasMutableFunctions(contract) &&
-                (this.showAllFiles || (!contract.path.startsWith('test/') && !contract.path.startsWith('lib/') && !contract.path.startsWith('script/')))
-        );
-        return visibleContracts.length > 0 && visibleContracts.every(c => c.enabled);
-    }
-
     private getContractsHtml(): string {
         if (this.contracts.length === 0) {
             return `
@@ -1325,7 +1316,7 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
         const visibleContracts = this.contracts
             .filter(contract =>
                 this.hasMutableFunctions(contract) &&
-                (this.showAllFiles || (!contract.path.startsWith('test/') && !contract.path.startsWith('src/test/') && !contract.path.endsWith('.t.sol') && !contract.path.endsWith('.s.sol') && !contract.path.startsWith('lib/') && !contract.path.startsWith('node_modules/') && !contract.path.startsWith('script/')))
+                (this.showAllFiles || (contract.name.includes("Mock") && (contract.path.startsWith('test/') || contract.path.startsWith('src/test/'))) || (!contract.path.startsWith('test/') && !contract.path.startsWith('src/test/') && !contract.path.endsWith('.t.sol') && !contract.path.endsWith('.s.sol') && !contract.path.startsWith('lib/') && !contract.path.startsWith('node_modules/') && !contract.path.startsWith('script/')))
             )
             .sort((a, b) => {
                 const aDepth = a.path.split('/').length;


### PR DESCRIPTION
Contract watcher now correctly tracks individual file changes in output folder