### PR TITLE
Add PATH variable to environment from VS Code settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "recon",
   "displayName": "Recon",
   "description": "Seamless integration of Foundry, Medusa, and Echidna for smart contract testing",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "license": "gpl-2.0",
   "publisher": "Recon-Fuzz",
   "repository": {


### PR DESCRIPTION
Problem:
When crytic-compile is installed with pipx in non-standard locations such as ~/.local/bin, Medusa is unable to locate it due to the $PATH not being inherited from VS Code settings.

Solution:
This PR updates the fuzzingCommands.ts file to inherit the $PATH from terminal.integrated.env.osx in the user's VS Code settings. This corrects the $PATH passed to child processes like Medusa.

Testing:
Tested on macOS with a custom $PATH set in settings.json (~/Library/Application Support/Code/User/settings.json)
Verified that crytic-compile is now found and executed correctly.

Reference:
For more information on configuring terminal environment variables in VS Code, see the official documentation: [Profiles in Visual Studio Code.](https://code.visualstudio.com/docs/terminal/profiles)

Note:
I do not have access to Windows or Linux to test this functionality on those platforms. However, the logic for handling terminal.integrated.env.windows and terminal.integrated.env.linux has been implemented based on platform detection (process.platform) and should work as expected. Feedback or testing from contributors on those platforms would be greatly appreciated.