### PR TITLE
feat: allow view only contracts to be added to extension

### DIFF
--- a/src/generators/manager.ts
+++ b/src/generators/manager.ts
@@ -47,9 +47,9 @@ export class TemplateManager {
             const reconContent = await fs.readFile(reconPath, 'utf8');
             const reconConfig = JSON.parse(reconContent);
 
-            // Only process contracts that have configured functions
+            // Process all enabled contracts, including those with only view/pure functions
             for (const [jsonPath, config] of Object.entries(reconConfig)) {
-                if ((config as any).functions?.length > 0) {
+                if ((config as any).enabled === true) {
                     try {
                         const fullPath = path.join(this.workspaceRoot, jsonPath);
                         const content = await fs.readFile(fullPath, 'utf8');


### PR DESCRIPTION
Repro:
Morpho Blue

MockIRM wouldn't show, now it does (but has no target functions since it's a view only contract)