### PR TITLE
VSX Registry and VSCode marketplace support.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,11 @@ jobs:
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          dryRun: true
 
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
+          dryRun: true


### PR DESCRIPTION
This PR extends the release workflow to automatically publish releases to the VSX registry and VSCode marketplace. It's based on the [publish-vscode-extension](https://github.com/HaaLeo/publish-vscode-extension) GitHub action.

The workflow uses bearer token authentication. The tokens must be configured in the GitHub repository secrets. Obviously, that's not something I can do.

```
secrets.OPEN_VSX_TOKEN
secrets.VS_MARKETPLACE_TOKEN
```

The workflow currently sets the `dryRun`-flag, so no actual artifacts are uploaded. This allows for easier debugging, but must be removed before merging this PR.