### PR TITLE
Add: warning message if echidna or medusa is not detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -338,12 +338,19 @@
           "order": 5,
           "description": "Number of workers for Echidna fuzzing"
         },
+        "recon.echidna.path": {
+          "type": "string",
+          "default": "",
+          "scope": "resource",
+          "order": 6,
+          "description": "Custom path to echidna binary (optional, uses PATH if empty)"
+        },
         "recon.medusa.testLimit": {
           "type": "number",
           "default": 0,
           "minimum": 0,
           "scope": "resource",
-          "order": 6,
+          "order": 7,
           "description": "Test limit for Medusa fuzzing"
         },
         "recon.medusa.workers": {
@@ -351,15 +358,22 @@
           "default": 10,
           "minimum": 1,
           "scope": "resource",
-          "order": 7,
+          "order": 8,
           "description": "Number of workers for Medusa fuzzing"
+        },
+        "recon.medusa.path": {
+          "type": "string",
+          "default": "",
+          "scope": "resource",
+          "order": 9,
+          "description": "Custom path to medusa binary (optional, uses PATH if empty)"
         },
         "recon.halmos.depth": {
           "type": "number",
           "default": 22,
           "minimum": 1,
           "scope": "resource",
-          "order": 8,
+          "order": 10,
           "description": "Maximum call depth for Halmos symbolic execution"
         },
         "recon.halmos.unroll": {
@@ -367,7 +381,7 @@
           "default": 256,
           "minimum": 1,
           "scope": "resource",
-          "order": 9,
+          "order": 11,
           "description": "Maximum loop unrolling factor for Halmos"
         },
         "recon.halmos.solver": {
@@ -380,7 +394,7 @@
             "bitwuzla",
             "yices"
           ],
-          "order": 10,
+          "order": 12,
           "description": "SMT solver to use for Halmos symbolic execution"
         },
         "recon.foundryConfigPath": {
@@ -388,14 +402,14 @@
           "default": "foundry.toml",
           "description": "Path to foundry.toml configuration file (relative to workspace root)",
           "scope": "resource",
-          "order": 11
+          "order": 13
         },
         "recon.forge.buildArgs": {
           "type": "string",
           "default": "",
           "description": "Extra arguments to pass to forge build command (e.g. --via-ir)",
           "scope": "resource",
-          "order": 12
+          "order": 14
         },
         "recon.forge.testVerbosity": {
           "type": "string",
@@ -409,28 +423,28 @@
           ],
           "description": "Verbosity level for forge test command",
           "scope": "resource",
-          "order": 13
+          "order": 15
         },
         "recon.mocksFolderPath": {
           "type": "string",
           "default": "test/recon/mocks",
           "description": "Path to store generated mock contracts (relative to foundry.toml location)",
           "scope": "resource",
-          "order": 14
+          "order": 16
         },
         "recon.mockAutoSave": {
           "type": "boolean",
           "default": true,
           "description": "Automatically save generated mock contracts to disk",
           "scope": "resource",
-          "order": 15
+          "order": 17
         },
         "recon.customTestFolderPath": {
           "type": "string",
           "default": "",
           "description": "Custom path for test files (relative to foundry.toml location). If empty, standard paths will be searched",
           "scope": "resource",
-          "order": 16
+          "order": 18
         }
       }
     }

--- a/src/services/toolValidationService.ts
+++ b/src/services/toolValidationService.ts
@@ -1,0 +1,65 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs/promises';
+import { checkCommandExists } from '../utils';
+
+export interface ValidationResult {
+    isValid: boolean;
+    error?: string;
+    command: string;
+}
+
+export class ToolValidationService {
+
+    public async validateFuzzer(fuzzerType: 'echidna' | 'medusa'): Promise<ValidationResult> {
+        const config = vscode.workspace.getConfiguration('recon');
+        const customPath = config.get<string>(`${fuzzerType}.path`, '');
+
+        let command: string;
+        let isValid: boolean;
+
+        // If custom path is set, check if it exists
+        if (customPath) {
+            try {
+                await fs.access(customPath);
+                command = customPath;
+                isValid = true;
+            } catch {
+                return {
+                    isValid: false,
+                    command: customPath,
+                    error: `Custom ${fuzzerType} path not found: ${customPath}\n\nPlease check your settings or remove the custom path to use the system PATH.`
+                };
+            }
+        } else {
+            // Check if command exists in PATH
+            command = fuzzerType;
+            isValid = await checkCommandExists(fuzzerType);
+
+            if (!isValid) {
+                return {
+                    isValid: false,
+                    command: fuzzerType,
+                    error: this.getInstallationWarning(fuzzerType)
+                };
+            }
+        }
+
+        return {
+            isValid: true,
+            command
+        };
+    }
+
+    /**
+     * Gets installation warning message with guidance
+     */
+    private getInstallationWarning(fuzzerType: 'echidna' | 'medusa'): string {
+        const toolName = fuzzerType.charAt(0).toUpperCase() + fuzzerType.slice(1);
+        const installGuides: Record<string, string> = {
+            echidna: 'https://github.com/crytic/echidna',
+            medusa: 'https://github.com/crytic/medusa'
+        };
+
+        return `${toolName} not found. Install it or set a custom path in settings.\n\n${installGuides[fuzzerType]}`;
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -288,3 +288,20 @@ export function getEnvironmentPath(): string {
 
     return Array.from(combined).join(':');
 }
+
+export async function checkCommandExists(command: string): Promise<boolean> {
+    try {
+        const checkCommand = process.platform === 'win32' ? 'where' : 'which';
+        execSync(`${checkCommand} ${command}`, {
+            encoding: 'utf-8',
+            stdio: 'pipe',
+            env: {
+                ...process.env,
+                PATH: getEnvironmentPath()
+            },
+        });
+       return true; 
+    } catch (error) {
+       return false; 
+    }
+}


### PR DESCRIPTION
### Overview

Adressess #42 

1. Added command detection for echidna/medusa before execution
2. Created validation service that checks custom paths or system PATH
3. Added config settings for custom tool paths
4. Show warning message if tool not found with "Open Settings" option

**Note:**
This should work on all operating systems (Windows/Mac/Linux), but I've only tested it on Windows.

**Preview:**

https://github.com/user-attachments/assets/a1c2a336-a3ce-4d14-b3f9-624be282eeb0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pre-run validation for Echidna/Medusa, supporting custom binary paths, warnings with Settings shortcut, and resolved command usage.
> 
> - **Fuzzing commands**:
>   - Validate `echidna`/`medusa` availability before execution; show warning with "Open Settings" and abort if missing.
>   - Use validated command (custom path or PATH) when building fuzzer CLI strings.
> - **Service**:
>   - Add `ToolValidationService` with `validateFuzzer` to check custom paths or PATH and provide install guidance.
> - **Utils**:
>   - Add `checkCommandExists` leveraging `which/where` with merged `PATH` from `getEnvironmentPath`.
> - **Configuration**:
>   - Add `recon.echidna.path` and `recon.medusa.path` settings for custom binary locations (adjust config orders).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b25ac7bca641ab55f3d38fe42a0cf720bdc511ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->