### PR TITLE
[RFC] Target tests/recon/CryticTester.sol instead of . when running echidna

### DIFF
--- a/src/commands/fuzzingCommands.ts
+++ b/src/commands/fuzzingCommands.ts
@@ -69,7 +69,7 @@ async function runFuzzer(
     const testLimit = config.get<number>("testLimit", 1000000);
     const mode = config.get<string>("mode", "assertion");
 
-    command = `echidna . --contract ${
+    command = `echidna tests/recon/CryticTester.sol --contract ${
       target || "CryticTester"
     } --config echidna.yaml --format text --workers ${
       workers || 10


### PR DESCRIPTION
This change should speed up the echidna start-up. Can you verify it is faster for you @GalloDaSballo ?