### PR TITLE
Use git submodules for chimera and setup-helpers dependencies

### DIFF
--- a/src/chimeraGenerator.ts
+++ b/src/chimeraGenerator.ts
@@ -112,7 +112,7 @@ export class ChimeraGenerator {
         } catch {
             const foundryRoot = await this.getFoundryRoot();
             await new Promise((resolve, reject) => {
-                exec('forge install Recon-Fuzz/chimera --no-git',
+                exec('forge install Recon-Fuzz/chimera',
                     { 
                         cwd: foundryRoot,
                         env: {
@@ -135,7 +135,7 @@ export class ChimeraGenerator {
         } catch {
             const foundryRoot = await this.getFoundryRoot();
             await new Promise((resolve, reject) => {
-                exec('forge install Recon-Fuzz/setup-helpers --no-git',
+                exec('forge install Recon-Fuzz/setup-helpers',
                     { 
                         cwd: foundryRoot,
                         env: {


### PR DESCRIPTION
## Summary

Remove `--no-git` flag from `forge install` commands to properly track dependencies as git submodules instead of copying files directly into the repository. This prevents polluting git history with vendored files.

## Changes

- Remove `--no-git` flag from `forge install Recon-Fuzz/chimera` in `installChimera()` 
- Remove `--no-git` flag from `forge install Recon-Fuzz/setup-helpers` in `installSetupHelpers()`

## Context

This implements the same fix as https://github.com/Recon-Fuzz/recon-generate/pull/2

The `--no-git` flag was causing dependencies to be copied directly into the repository instead of being tracked as submodules, which pollutes git history with vendored files when committed.

/cc @aviggiano

🤖 Generated with [Claude Code](https://claude.com/claude-code)