### PR TITLE
fix(utils): use OS-correct PATH separator in getEnvironmentPath (Windows)

### DIFF
--- a/src/test/combinePathSources.test.ts
+++ b/src/test/combinePathSources.test.ts
@@ -1,0 +1,131 @@
+import * as assert from 'assert';
+import { combinePathSources } from '../utils';
+
+/**
+ * Pure-TS unit tests for `combinePathSources()`.
+ *
+ * Regression guard for the bug where `getEnvironmentPath()` used the Unix
+ * PATH separator (`:`) on Windows. That corrupted any Windows path containing
+ * a drive letter (e.g. `C:\Users\...`) and caused spawned `forge`, `echidna`,
+ * `medusa`, `halmos` processes to fail with "command not found" on Windows.
+ *
+ * Uses Mocha TDD interface (`suite` / `test`) — the default for VS Code
+ * extension tests under `@vscode/test-cli`.
+ */
+suite('combinePathSources()', () => {
+    // ---- Windows -------------------------------------------------------
+
+    suite('on win32', () => {
+        const plat: NodeJS.Platform = 'win32';
+        const sep = ';';
+
+        test('joins userPath + defaultPath using the Windows separator', () => {
+            const out = combinePathSources(
+                'C:\\Users\\me\\bin',
+                '',
+                'C:\\Windows\\System32;C:\\Windows',
+                plat,
+                sep,
+            );
+            assert.strictEqual(
+                out,
+                'C:\\Users\\me\\bin;C:\\Windows\\System32;C:\\Windows',
+            );
+        });
+
+        test('returns defaultPath when userPath is empty', () => {
+            const out = combinePathSources(
+                '',
+                '',
+                'C:\\Windows\\System32;C:\\Windows',
+                plat,
+                sep,
+            );
+            assert.strictEqual(out, 'C:\\Windows\\System32;C:\\Windows');
+        });
+
+        test('does NOT split on ":" (preserves drive letters like C:\\...)', () => {
+            const userPath = 'C:\\Users\\me\\.foundry\\bin';
+            const defaultPath = 'C:\\Windows\\System32';
+            const out = combinePathSources(userPath, '', defaultPath, plat, sep);
+            // Drive letters must survive intact.
+            assert.ok(out.includes('C:\\Users\\me\\.foundry\\bin'));
+            assert.ok(out.includes('C:\\Windows\\System32'));
+            const parts = out.split(';');
+            assert.deepStrictEqual(parts, [
+                'C:\\Users\\me\\.foundry\\bin',
+                'C:\\Windows\\System32',
+            ]);
+        });
+
+        test('does not read shellPath on Windows (no login shell)', () => {
+            const out = combinePathSources(
+                'C:\\a',
+                'C:\\b', // would be present on posix, ignored on windows
+                'C:\\c',
+                plat,
+                sep,
+            );
+            assert.strictEqual(out, 'C:\\a;C:\\c');
+            assert.ok(!out.includes('C:\\b'));
+        });
+
+        test('returns empty string when every input is empty', () => {
+            const out = combinePathSources('', '', '', plat, sep);
+            assert.strictEqual(out, '');
+        });
+    });
+
+    // ---- POSIX (linux / darwin) ----------------------------------------
+
+    suite('on posix (linux/darwin)', () => {
+        const plat: NodeJS.Platform = 'linux';
+        const sep = ':';
+
+        test('merges all three sources deduplicated with ":"', () => {
+            const out = combinePathSources(
+                '/home/me/bin',
+                '/usr/local/bin:/home/me/bin',
+                '/usr/bin:/bin',
+                plat,
+                sep,
+            );
+            const parts = out.split(':');
+            // All uniques must appear; order preserves first-seen.
+            assert.deepStrictEqual(parts, [
+                '/home/me/bin',
+                '/usr/local/bin',
+                '/usr/bin',
+                '/bin',
+            ]);
+        });
+
+        test('drops empty-string fragments from consecutive colons', () => {
+            const out = combinePathSources(
+                '',
+                '::/usr/local/bin::',
+                '/usr/bin::',
+                plat,
+                sep,
+            );
+            assert.ok(!out.split(':').includes(''), 'no empty segments allowed');
+            assert.ok(out.includes('/usr/local/bin'));
+            assert.ok(out.includes('/usr/bin'));
+        });
+
+        test('darwin behaves like linux', () => {
+            const out = combinePathSources(
+                '/Users/me/bin',
+                '/opt/homebrew/bin',
+                '/usr/bin',
+                'darwin',
+                sep,
+            );
+            assert.deepStrictEqual(out.split(':'), [
+                '/Users/me/bin',
+                '/opt/homebrew/bin',
+                '/usr/bin',
+            ]);
+        });
+    });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -255,6 +255,37 @@ export async function cleanupCoverageReport(workspaceRoot: string, content: stri
     }
 }
 
+/**
+ * Pure helper — kept separate from `getEnvironmentPath()` so it can be unit-tested
+ * without a live VS Code extension host.
+ *
+ * Combines the user-configured PATH, the login-shell PATH, and the current
+ * process PATH into a single deduplicated PATH string using the correct
+ * OS separator (`;` on Windows, `:` elsewhere).
+ *
+ * On Windows the shell-PATH source is unused (no login shell is sourced), so
+ * the result is `userPath + sep + defaultPath` when `userPath` is non-empty,
+ * or just `defaultPath` otherwise. This mirrors prior behaviour but with the
+ * correct separator so Windows paths like `C:\foo` are not split on `:`.
+ */
+export function combinePathSources(
+    userPath: string,
+    shellPath: string,
+    defaultPath: string,
+    platform: NodeJS.Platform = process.platform,
+    sep: string = path.delimiter,
+): string {
+    if (platform === 'win32') {
+        return userPath ? `${userPath}${sep}${defaultPath}` : defaultPath;
+    }
+    const combined = new Set([
+        ...userPath.split(sep),
+        ...shellPath.split(sep),
+        ...defaultPath.split(sep),
+    ].filter(Boolean));
+    return Array.from(combined).join(sep);
+}
+
 export function getEnvironmentPath(): string {
     const defaultPath = process.env.PATH || '';
 
@@ -276,15 +307,7 @@ export function getEnvironmentPath(): string {
         } catch (e) {
             console.warn('Failed to get shell PATH:', e);
         }
-    } else {
-        return userPath ? `${userPath}:${process.env.PATH}` : process.env.PATH || '';
     }
 
-    const combined = new Set([
-        ...userPath.split(':'),
-        ...shellPath.split(':'),
-        ...defaultPath.split(':'),
-    ].filter(Boolean));
-
-    return Array.from(combined).join(':');
+    return combinePathSources(userPath, shellPath, defaultPath);
 }


### PR DESCRIPTION
## Summary

`getEnvironmentPath()` built the PATH with the Unix separator `:` on Windows, corrupting drive-letter paths (e.g. `C:\Users\me\bin`) and causing every spawned `forge`, `echidna`, `medusa`, and `halmos` child process to fail with *command not found* on Windows. This is one of the concrete root-causes behind the "extension is broken on Windows" report in #62.

## Root cause (1 line)

`src/utils.ts :: getEnvironmentPath()` hardcoded `:` both in the Windows branch (`return userPath ? \`${userPath}:${process.env.PATH}\` : ...`) and in the subsequent `.split(':') / .join(':')` merge — Windows PATH requires `;` (== `path.delimiter`).

## Reproducer

On Windows, with a user-configured `terminal.integrated.env.windows.PATH` set to (e.g.) `C:\Users\me\.foundry\bin`, calling `getEnvironmentPath()` returns `"C:\Users\me\.foundry\bin:C:\Windows\System32;..."`. The first path token becomes the literal string `"C:\Users\me\.foundry\bin:C"` because Windows PATH parsing splits on `;`, not `:`. Any `spawn('forge', ..., { env: { PATH: getEnvironmentPath() } })` then fails because no PATH entry actually points to a valid directory.

## What the fix does

- Extracts the pure path-merging logic into a new exported `combinePathSources(userPath, shellPath, defaultPath, platform, sep)` helper, so it can be unit-tested without booting the extension host.
- Uses `path.delimiter` (== `';'` on Win32, `':'` elsewhere) everywhere.
- Special-cases Windows to skip the posix-only login-shell PATH source (there is no `$SHELL -ilc 'echo $PATH'` on Windows). Behaviour on posix is unchanged.
- Leaves `getEnvironmentPath()` as the thin VS Code-aware wrapper that reads `terminal.integrated.env.<platform>.PATH` and delegates to the helper.

## Test coverage added

- `src/test/combinePathSources.test.ts` — 8 new Mocha TDD tests (5 Windows + 3 POSIX):
  - Windows: join with `;`, empty-userPath fallback, drive-letter preservation (the regression guard for this bug), shellPath is ignored on Windows, all-empty inputs.
  - POSIX: three-source dedup, empty-fragment handling, darwin === linux.
- Runs clean under `npx vscode-test` in the existing `@vscode/test-cli` harness (no new dev-deps required):
  ```
    combinePathSources()
      on win32
        ✔ joins userPath + defaultPath using the Windows separator
        ✔ returns defaultPath when userPath is empty
        ✔ does NOT split on ":" (preserves drive letters like C:\...)
        ✔ does not read shellPath on Windows (no login shell)
        ✔ returns empty string when every input is empty
      on posix (linux/darwin)
        ✔ merges all three sources deduplicated with ":"
        ✔ drops empty-string fragments from consecutive colons
        ✔ darwin behaves like linux
    8 passing
  ```

- `npx eslint src` clean (0 errors, pre-existing 6 warnings unchanged).
- `npx tsc -p ./` clean.

## Scope

Only `src/utils.ts` + new `src/test/combinePathSources.test.ts`. No behavioural change on macOS / Linux — the posix branch produces the identical deduplicated-set output it did before.

Closes (partial) #62.

/claim #62