### PR TITLE
fix: UX & some extra safety checks enforcements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ node_modules
 *.vsix
 .npmrc
 .idea/
-.npmrc
+.DS_Store

--- a/src/commands/buildCommands.ts
+++ b/src/commands/buildCommands.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { exec } from 'child_process';
+import { exec, spawn } from 'child_process';
 import { getEnvironmentPath, getFoundryConfigPath } from '../utils';
 import { ServiceContainer } from '../services/serviceContainer';
 
@@ -36,38 +36,45 @@ export function registerBuildCommands(
                 cancellable: true
             }, async (progress, token) => {
                 return new Promise((resolve, reject) => {
-                    const buildProcess = exec(`forge build ${extraBuildArgs}`.trim(),
-                        {
-                            cwd: foundryRoot,
-                            env: {
-                                ...process.env,
-                                PATH: getEnvironmentPath()
-                            }
-                        },
-                        (error, stdout, stderr) => {
-                            if (error && !token.isCancellationRequested) {
-                                const errorMsg = `Build failed: ${error.message}`;
-                                outputChannel.appendLine(errorMsg);
-                                vscode.window.showErrorMessage(errorMsg);
-                                reject(error);
-                                return;
-                            }
-                            if (stdout) {
-                                outputChannel.appendLine(stdout);
-                            }
-                            if (stderr) {
-                                outputChannel.appendLine('Build warnings:');
-                                outputChannel.appendLine(stderr);
-                            }
-                            if (!token.isCancellationRequested) {
-                                outputChannel.appendLine('Build completed successfully');
-                                vscode.window.showInformationMessage('Build completed successfully');
-                                vscode.commands.executeCommand('recon.refreshContracts');
-                                services.contractWatcherService.checkAndLoadContracts();
-                                resolve(stdout);
-                            }
+                    const args = ['build', ...extraBuildArgs.split(/\s+/).filter(Boolean)];
+                    const buildProcess = spawn('forge', args, {
+                        cwd: foundryRoot,
+                        env: {
+                            ...process.env,
+                            PATH: getEnvironmentPath()
                         }
-                    );
+                    });
+
+                    let stdout = '';
+                    let stderr = '';
+
+                    buildProcess.stdout.on('data', (data: Buffer) => {
+                        const text = data.toString();
+                        stdout += text;
+                        outputChannel.append(text);
+                    });
+
+                    buildProcess.stderr.on('data', (data: Buffer) => {
+                        const text = data.toString();
+                        stderr += text;
+                        outputChannel.append(text);
+                    });
+
+                    buildProcess.on('close', (code: number) => {
+                        if (token.isCancellationRequested) { return; }
+                        if (code !== 0) {
+                            const errorMsg = `Build failed with exit code ${code}`;
+                            outputChannel.appendLine(errorMsg);
+                            vscode.window.showErrorMessage(errorMsg);
+                            reject(new Error(errorMsg));
+                            return;
+                        }
+                        outputChannel.appendLine('Build completed successfully');
+                        vscode.window.showInformationMessage('Build completed successfully');
+                        vscode.commands.executeCommand('recon.refreshContracts');
+                        services.contractWatcherService.checkAndLoadContracts();
+                        resolve(stdout);
+                    });
 
                     token.onCancellationRequested(() => {
                         buildProcess.kill();

--- a/src/commands/fuzzingCommands.ts
+++ b/src/commands/fuzzingCommands.ts
@@ -232,7 +232,7 @@ async function runFuzzer(
     }
     const replayFlag =
       opts.useReconWrapper && opts.replayFile
-        ? ` --replay "${opts.replayFile.replace(/"/g, '\\"')}"`
+        ? ` --replay '${opts.replayFile.replace(/'/g, "'\\''")}'`
         : "";
     command = `${binary} . --contract ${
       target || "CryticTester"

--- a/src/commands/fuzzingCommands.ts
+++ b/src/commands/fuzzingCommands.ts
@@ -191,7 +191,8 @@ async function runFuzzer(
   const foundryConfigPath = getFoundryConfigPath(workspaceRoot);
   const foundryRoot = path.dirname(foundryConfigPath);
 
-  let command: string;
+  let cmdBinary: string;
+  let cmdArgs: string[];
   let webUiEnabled = false;
 
   if (fuzzerType === Fuzzer.ECHIDNA) {
@@ -203,42 +204,39 @@ async function runFuzzer(
 
     // Pick the binary: recon fuzz wrapper, the validated custom echidna
     // path, or `echidna` from PATH.
-    const binary = opts.useReconWrapper ? "recon fuzz" : (validatedCommand || "echidna");
-    // Recon Fuzzer writes corpus + coverage to ./recon/ so we can tell its
-    // output apart from raw Echidna's ./echidna/ output. The HTML reports
-    // recon produces are already cleaned, so we won't need a cleanup pass.
-    //
-    // When the user opts in to "generate echidna corpus" we keep Echidna's
-    // own corpus too (--recon-corpus-dir). Otherwise the combined Recon
-    // corpus replaces it (--corpus-dir).
-    let corpusFlag = "";
-    let mutableOnlyFlag = "";
-    let webFlag = "";
+    // Args array prevents command injection — each value is a separate
+    // argv element, never parsed by a shell.
+    if (opts.useReconWrapper) {
+      cmdBinary = "recon";
+      cmdArgs = ["fuzz"];
+    } else {
+      cmdBinary = validatedCommand || "echidna";
+      cmdArgs = [];
+    }
+    cmdArgs.push(".", "--contract", target || "CryticTester",
+      "--config", "echidna.yaml", "--format", "text",
+      "--workers", String(workers || 10),
+      "--test-limit", String(testLimit), "--test-mode", mode);
+
     if (opts.useReconWrapper) {
       const reconCfg = vscode.workspace.getConfiguration("recon.reconFuzzer");
       const keepEchidnaCorpus = reconCfg.get<boolean>("generateEchidnaCorpus", false);
-      corpusFlag = keepEchidnaCorpus
-        ? " --recon-corpus-dir recon"
-        : " --corpus-dir recon";
+      // Recon Fuzzer writes corpus + coverage to ./recon/ so we can tell
+      // its output apart from raw Echidna's ./echidna/ output.
+      cmdArgs.push(keepEchidnaCorpus ? "--recon-corpus-dir" : "--corpus-dir", "recon");
       if (reconCfg.get<boolean>("skipPureViewFunctions", false)) {
-        mutableOnlyFlag = " --mutable-only";
+        cmdArgs.push("--mutable-only");
       }
-      // --web is interactive and incompatible with a one-shot replay run, so
-      // skip it for replays even if the setting is enabled.
+      // --web is interactive and incompatible with a one-shot replay run,
+      // so skip it for replays even if the setting is enabled.
       if (reconCfg.get<boolean>("webUi", false) && !opts.replayFile) {
-        webFlag = " --web --no-open";
+        cmdArgs.push("--web", "--no-open");
         webUiEnabled = true;
       }
+      if (opts.replayFile) {
+        cmdArgs.push("--replay", opts.replayFile);
+      }
     }
-    const replayFlag =
-      opts.useReconWrapper && opts.replayFile
-        ? ` --replay '${opts.replayFile.replace(/'/g, "'\\''")}'`
-        : "";
-    command = `${binary} . --contract ${
-      target || "CryticTester"
-    } --config echidna.yaml --format text --workers ${
-      workers || 10
-    } --test-limit ${testLimit} --test-mode ${mode}${corpusFlag}${mutableOnlyFlag}${webFlag}${replayFlag}`;
 
     if (webUiEnabled) {
       openReconFuzzerWebPanel();
@@ -249,18 +247,19 @@ async function runFuzzer(
     const workers = getWorkerConfig('medusa');
     const testLimit = config.get<number>("testLimit", 0);
 
-    command = `${validatedCommand || "medusa"} fuzz --workers ${
-      workers || 10
-    } --test-limit ${testLimit}`;
+    cmdBinary = validatedCommand || "medusa";
+    cmdArgs = ["fuzz", "--workers", String(workers || 10),
+      "--test-limit", String(testLimit)];
     if (target !== "CryticTester") {
-      command += ` --target-contracts ${target || "CryticTester"}`;
+      cmdArgs.push("--target-contracts", target || "CryticTester");
     }
   } else {
     const config = vscode.workspace.getConfiguration("recon.halmos");
     const loop = config.get<number>("loop", 256);
 
-    command = `halmos --match-contract ${target || "CryticTester"
-      } -vv --solver-timeout-assertion 0 --loop ${loop} `;
+    cmdBinary = "halmos";
+    cmdArgs = ["--match-contract", target || "CryticTester",
+      "-vv", "--solver-timeout-assertion", "0", "--loop", String(loop)];
   }
 
   // Display label distinguishes the Recon-wrapped Echidna from raw Echidna,
@@ -302,10 +301,9 @@ async function runFuzzer(
           progress.report({ message: `Web UI running · open ${RECON_FUZZER_WEB_URL} — Cancel to stop` });
         }
 
-        childProcess = require("child_process").spawn(command, {
+        childProcess = require("child_process").spawn(cmdBinary, cmdArgs, {
           cwd: foundryRoot,
-          shell: true,
-          ...(process.platform === "win32" 
+          ...(process.platform === "win32"
             ? { stdio: "pipe", detached: false }
             : { stdio: "pipe", detached: true }),
           env: {

--- a/src/coverageView.ts
+++ b/src/coverageView.ts
@@ -201,7 +201,7 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
             'coverageReport',
             path.basename(htmlPath),
             vscode.ViewColumn.One,
-            { enableScripts: true, retainContextWhenHidden: true }
+            { enableScripts: false, retainContextWhenHidden: true }
         );
         panel.webview.html = content;
     }
@@ -267,7 +267,7 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
             path.basename(cleanedHtmlPath), // Use the filename as the panel title
             vscode.ViewColumn.One,
             {
-                enableScripts: true,
+                enableScripts: false,
                 retainContextWhenHidden: true,
                 enableFindWidget: true
             }
@@ -757,9 +757,9 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
                             </div>
                             <div class="coverage-actions">
                                 ${file.type === FuzzerTool.ECHIDNA ? `
-                                    <i class="codicon codicon-checklist coverage-stats" onclick="showCoverageStats('${file.path}', event)" title="Coverage Stats"></i>
+                                    <i class="codicon codicon-checklist coverage-stats" onclick="showCoverageStats('${escapeHtml(file.path)}', event)" title="Coverage Stats"></i>
                                 ` : ''}
-                                <i class="codicon codicon-link-external external-link" onclick="openExternal('${file.path}', event)" title="Open in browser"></i>
+                                <i class="codicon codicon-link-external external-link" onclick="openExternal('${escapeHtml(file.path)}', event)" title="Open in browser"></i>
                             </div>
                         </div>
                     `).join('')}

--- a/src/coverageView.ts
+++ b/src/coverageView.ts
@@ -6,7 +6,8 @@ import { CoverageFile, FuzzerTool } from './types';
 import { readCoverageFileAndProcess } from 'echidna-coverage-parser';
 
 function escapeHtml(s: string): string {
-    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
 export class CoverageViewProvider implements vscode.WebviewViewProvider {

--- a/src/coverageView.ts
+++ b/src/coverageView.ts
@@ -5,6 +5,10 @@ import { findSrcDirectory, getFoundryConfigPath } from './utils';
 import { CoverageFile, FuzzerTool } from './types';
 import { readCoverageFileAndProcess } from 'echidna-coverage-parser';
 
+function escapeHtml(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 export class CoverageViewProvider implements vscode.WebviewViewProvider {
     private _view?: vscode.WebviewView;
     private _filesWatcher?: vscode.FileSystemWatcher;
@@ -190,7 +194,9 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
             vscode.window.showWarningMessage(`Recon AI: HTML report not found · ${htmlPath}`);
             return;
         }
-        const content = await fs.readFile(htmlPath, 'utf8');
+        let content = await fs.readFile(htmlPath, 'utf8');
+        const csp = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:;">`;
+        content = content.replace('<head>', '<head>' + csp);
         const panel = vscode.window.createWebviewPanel(
             'coverageReport',
             path.basename(htmlPath),
@@ -251,8 +257,9 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
             </style>
         `;
 
-        // Insert reset styles after the first <head> tag
-        content = content.replace('<head>', '<head>' + resetStyles);
+        // Insert CSP and reset styles after the first <head> tag
+        const cspCleaned = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:;">`;
+        content = content.replace('<head>', '<head>' + cspCleaned + resetStyles);
         
         // Create a new webview panel with the filename as title
         const panel = vscode.window.createWebviewPanel(
@@ -454,9 +461,9 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
                     </div>
                     <div id="content">
                         ${filesData.map(data => `
-                            <div class="file-section" data-path="${data.path}">
+                            <div class="file-section" data-path="${escapeHtml(data.path)}">
                                 <div class="file-header">
-                                    <div class="file-path">📄 ${data.path}</div>
+                                    <div class="file-path">📄 ${escapeHtml(data.path)}</div>
                                     <div class="coverage-stats">
                                         <div class="stat-item">
                                             <span>Functions:</span>
@@ -479,7 +486,7 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
                                     <tbody>
                                         ${data.data.map(func => `
                                             <tr>
-                                                <td class="function-name">${func.functionName}</td>
+                                                <td class="function-name">${escapeHtml(func.functionName)}</td>
                                                 <td>
                                                     ${func.isFullyCovered ? 
                                                         `<span class="status-tag status-covered">✓ Covered</span>` :
@@ -497,7 +504,7 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
                                             ${func.untouchedContent.length > 0 ? `
                                                 <tr>
                                                     <td colspan="3">
-                                                        <pre class="untouched-code">${func.untouchedContent.join('\n')}</pre>
+                                                        <pre class="untouched-code">${escapeHtml(func.untouchedContent.join('\n'))}</pre>
                                                     </td>
                                                 </tr>
                                             ` : ''}
@@ -750,9 +757,9 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
                             </div>
                             <div class="coverage-actions">
                                 ${file.type === FuzzerTool.ECHIDNA ? `
-                                    <i class="codicon codicon-checklist coverage-stats" onclick="showCoverageStats('${file.path}')" title="Coverage Stats"></i>
+                                    <i class="codicon codicon-checklist coverage-stats" onclick="showCoverageStats('${file.path}', event)" title="Coverage Stats"></i>
                                 ` : ''}
-                                <i class="codicon codicon-link-external external-link" onclick="openExternal('${file.path}')" title="Open in browser"></i>
+                                <i class="codicon codicon-link-external external-link" onclick="openExternal('${file.path}', event)" title="Open in browser"></i>
                             </div>
                         </div>
                     `).join('')}
@@ -780,7 +787,7 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
                         });
                     }
 
-                    function openExternal(path) {
+                    function openExternal(path, event) {
                         event.stopPropagation();
                         vscode.postMessage({
                             type: 'openExternal',
@@ -788,7 +795,7 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
                         });
                     }
 
-                    function showCoverageStats(path) {
+                    function showCoverageStats(path, event) {
                         event.stopPropagation();
                         vscode.postMessage({
                             type: 'showCoverageStats',

--- a/src/reconContractsView.ts
+++ b/src/reconContractsView.ts
@@ -555,7 +555,7 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
                         opacity: 0.7;
                         font-size: 10px;
                         margin-top: 2px;
-                        font-family: var (--vscode-editor-font-family);
+                        font-family: var(--vscode-editor-font-family);
                         cursor: pointer;
                         white-space: nowrap;
                         overflow: hidden;
@@ -1487,7 +1487,7 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
                                             <span class="optimized-radio">
                                                 <label class="radio-label ${config.mode === Mode.CANARY ? 'selected' : ''}" 
                                                        data-value="canary" 
-                                                       onclick="updateFunctionSetting('${contract.name}', '${signature}', 'mode', 'canary', this)">
+                                                       onclick="updateFunctionSetting('${contract.jsonPath}', '${signature}', 'mode', 'canary', this)">
                                                     Canary
                                                 </label>
                                             </span>

--- a/src/reconContractsView.ts
+++ b/src/reconContractsView.ts
@@ -3,6 +3,11 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { ContractMetadata, FunctionConfig, Abi, Actor, Mode } from './types';
 
+function escapeHtmlAttr(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
 export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
     private _view?: vscode.WebviewView;
     private contracts: ContractMetadata[] = [];
@@ -761,6 +766,10 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
                     </div>
                 ` : ''}
                 <script>
+                    function escapeHtml(s) {
+                        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                                .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+                    }
                     const vscode = acquireVsCodeApi();
                     
                     // Store any state that will be needed between reloads
@@ -950,43 +959,45 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
                                 if (!contentDiv) {
                                     contentDiv = document.createElement('div');
                                     contentDiv.className = 'function-content';
+                                    const safeContract = escapeHtml(contractName);
+                                    const safeSig = escapeHtml(fn.signature);
                                     contentDiv.innerHTML = \`
                                         <div class="function-settings">
                                             <div class="optimized-radio-group" data-type="mode">
                                                 <span class="optimized-radio">
-                                                    <label class="radio-label \${config.mode === 'normal' ? 'selected' : ''}" 
-                                                           data-value="normal" 
-                                                           onclick="updateFunctionSetting('\${contractName}', '\${fn.signature}', 'mode', 'normal', this)">
+                                                    <label class="radio-label \${config.mode === 'normal' ? 'selected' : ''}"
+                                                           data-value="normal"
+                                                           onclick="updateFunctionSetting('\${safeContract}', '\${safeSig}', 'mode', 'normal', this)">
                                                         Normal
                                                     </label>
                                                 </span>
                                                 <span class="optimized-radio">
-                                                    <label class="radio-label \${config.mode === 'fail' ? 'selected' : ''}" 
-                                                           data-value="fail" 
-                                                           onclick="updateFunctionSetting('\${contractName}', '\${fn.signature}', 'mode', 'fail', this)">
+                                                    <label class="radio-label \${config.mode === 'fail' ? 'selected' : ''}"
+                                                           data-value="fail"
+                                                           onclick="updateFunctionSetting('\${safeContract}', '\${safeSig}', 'mode', 'fail', this)">
                                                         Fail
                                                     </label>
                                                 </span>
                                                 <span class="optimized-radio">
-                                                    <label class="radio-label \${config.mode === 'catch' ? 'selected' : ''}" 
-                                                           data-value="catch" 
-                                                           onclick="updateFunctionSetting('\${contractName}', '\${fn.signature}', 'mode', 'catch', this)">
+                                                    <label class="radio-label \${config.mode === 'catch' ? 'selected' : ''}"
+                                                           data-value="catch"
+                                                           onclick="updateFunctionSetting('\${safeContract}', '\${safeSig}', 'mode', 'catch', this)">
                                                         Catch
                                                     </label>
                                                 </span>
                                             </div>
                                             <div class="optimized-radio-group" data-type="actor">
                                                 <span class="optimized-radio">
-                                                    <label class="radio-label \${config.actor === 'actor' ? 'selected' : ''}" 
-                                                           data-value="actor" 
-                                                           onclick="updateFunctionSetting('\${contractName}', '\${fn.signature}', 'actor', 'actor', this)">
+                                                    <label class="radio-label \${config.actor === 'actor' ? 'selected' : ''}"
+                                                           data-value="actor"
+                                                           onclick="updateFunctionSetting('\${safeContract}', '\${safeSig}', 'actor', 'actor', this)">
                                                         Actor
                                                     </label>
                                                 </span>
                                                 <span class="optimized-radio">
-                                                    <label class="radio-label \${config.actor === 'admin' ? 'selected' : ''}" 
-                                                           data-value="admin" 
-                                                           onclick="updateFunctionSetting('\${contractName}', '\${fn.signature}', 'actor', 'admin', this)">
+                                                    <label class="radio-label \${config.actor === 'admin' ? 'selected' : ''}"
+                                                           data-value="admin"
+                                                           onclick="updateFunctionSetting('\${safeContract}', '\${safeSig}', 'actor', 'admin', this)">
                                                         Admin
                                                     </label>
                                                 </span>
@@ -1075,32 +1086,32 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
                         });
                     }
 
-                    // Fuzzy search matching function
+                    // Fuzzy search matching function — escapes HTML in text
+                    // segments to prevent XSS via innerHTML assignment.
                     function fuzzyMatch(text, search) {
                         if (!search || search.trim() === '') {
-                            // Return the original text without highlights when search is empty
-                            return { match: true, score: 0, highlighted: text };
+                            return { match: true, score: 0, highlighted: escapeHtml(text) };
                         }
-                        
+
                         search = search.toLowerCase();
                         const textLower = text.toLowerCase();
-                        
+
                         // Direct substring match (higher priority)
                         if (textLower.includes(search)) {
                             const index = textLower.indexOf(search);
-                            const highlighted = text.substring(0, index) +
-                                '<span class="highlight">' + text.substring(index, index + search.length) + '</span>' +
-                                text.substring(index + search.length);
+                            const highlighted = escapeHtml(text.substring(0, index)) +
+                                '<span class="highlight">' + escapeHtml(text.substring(index, index + search.length)) + '</span>' +
+                                escapeHtml(text.substring(index + search.length));
                             return { match: true, score: 0, highlighted };
                         }
-                        
+
                         // Fuzzy matching
                         let searchIdx = 0;
                         let score = 0;
                         let lastMatchIdx = -1;
                         let consecutive = 0;
                         const matchPositions = [];
-                        
+
                         for (let i = 0; i < textLower.length && searchIdx < search.length; i++) {
                             if (textLower[i] === search[searchIdx]) {
                                 if (lastMatchIdx === i - 1) {
@@ -1109,27 +1120,27 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
                                 } else {
                                     consecutive = 0;
                                 }
-                                
+
                                 score += i;
                                 lastMatchIdx = i;
                                 matchPositions.push(i);
                                 searchIdx++;
                             }
                         }
-                        
+
                         const match = searchIdx === search.length;
-                        
+
                         let highlighted = '';
                         if (match) {
                             let lastPos = 0;
                             for (const pos of matchPositions) {
-                                highlighted += text.substring(lastPos, pos);
-                                highlighted += '<span class="highlight">' + text[pos] + '</span>';
+                                highlighted += escapeHtml(text.substring(lastPos, pos));
+                                highlighted += '<span class="highlight">' + escapeHtml(text[pos]) + '</span>';
                                 lastPos = pos + 1;
                             }
-                            highlighted += text.substring(lastPos);
+                            highlighted += escapeHtml(text.substring(lastPos));
                         } else {
-                            highlighted = text;
+                            highlighted = escapeHtml(text);
                         }
                         
                         return { match, score, highlighted };
@@ -1396,34 +1407,34 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
     private renderContractItem(contract: ContractMetadata, index: number, array: ContractMetadata[]): string {
         return `
             <div class="contract-group">
-                <div class="contract-item" data-path-name="${contract.jsonPath}" data-name="${contract.name}" data-path="${contract.path}">
+                <div class="contract-item" data-path-name="${escapeHtmlAttr(contract.jsonPath)}" data-name="${escapeHtmlAttr(contract.name)}" data-path="${escapeHtmlAttr(contract.path)}">
                     <div class="contract-header">
                         <div class="contract-title">
                             ${contract.enabled ? `
-                                <button class="toggle-button" onclick="toggleCollapse('${contract.jsonPath}')">
+                                <button class="toggle-button" onclick="toggleCollapse('${escapeHtmlAttr(contract.jsonPath)}')">
                                     <i class="codicon ${this.collapsedContracts.has(contract.jsonPath) ? 'codicon-chevron-right' : 'codicon-chevron-down'}"></i>
                                 </button>
                             ` : ''}
                             <vscode-checkbox
                                 class="contract-checkbox"
-                                id="contract-${contract.jsonPath}"
+                                id="contract-${escapeHtmlAttr(contract.jsonPath)}"
                                 ${contract.enabled ? 'checked' : ''}
-                                onchange="toggleContract('${contract.jsonPath}', this.checked)"
+                                onchange="toggleContract('${escapeHtmlAttr(contract.jsonPath)}', this.checked)"
                             >
-                                <span class="contract-name">${contract.name}</span>
+                                <span class="contract-name">${escapeHtmlAttr(contract.name)}</span>
                             </vscode-checkbox>
                             ${contract.enabled ? `
                                 <vscode-checkbox
                                     class="contract-separated-checkbox"
-                                    id="contract-separated-${contract.jsonPath}"
+                                    id="contract-separated-${escapeHtmlAttr(contract.jsonPath)}"
                                     ${contract.separated !== false ? 'checked' : ''}
-                                    onchange="toggleContractSeparated('${contract.jsonPath}', this.checked)"
+                                    onchange="toggleContractSeparated('${escapeHtmlAttr(contract.jsonPath)}', this.checked)"
                                 >
                                     Separated
                                 </vscode-checkbox>
                             ` : ''}
                         </div>
-                        <div class="contract-path" data-path="${contract.path}">${contract.path}</div>
+                        <div class="contract-path" data-path="${escapeHtmlAttr(contract.path)}">${escapeHtmlAttr(contract.path)}</div>
                     </div>
                     ${contract.enabled ? `
                         <div class="functions-list ${this.collapsedContracts.has(contract.jsonPath) ? 'collapsed' : ''}">
@@ -1454,16 +1465,18 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
             };
             const isEnabled = contract.enabledFunctions?.includes(signature);
 
+            const ePath = escapeHtmlAttr(contract.jsonPath);
+            const eSig = escapeHtmlAttr(signature);
             return `
                         <div class="function-item">
                             <div class="function-header">
                                 <vscode-checkbox
                                     class="function-checkbox"
-                                    data-function="${signature}"
+                                    data-function="${eSig}"
                                     ${isEnabled ? 'checked' : ''}
-                                    onchange="toggleFunction('${contract.jsonPath}', '${signature}', this.checked)"
+                                    onchange="toggleFunction('${ePath}', '${eSig}', this.checked)"
                                 >
-                                    <span class="function-name" title="${signature}">${signature}</span>
+                                    <span class="function-name" title="${eSig}">${eSig}</span>
                                 </vscode-checkbox>
                             </div>
                             ${isEnabled ? `
@@ -1471,46 +1484,46 @@ export class ReconContractsViewProvider implements vscode.WebviewViewProvider {
                                     <div class="function-settings">
                                         <div class="optimized-radio-group" data-type="mode">
                                             <span class="optimized-radio">
-                                                <label class="radio-label ${config.mode === Mode.NORMAL ? 'selected' : ''}" 
-                                                       data-value="normal" 
-                                                       onclick="updateFunctionSetting('${contract.jsonPath}', '${signature}', 'mode', 'normal', this)">
+                                                <label class="radio-label ${config.mode === Mode.NORMAL ? 'selected' : ''}"
+                                                       data-value="normal"
+                                                       onclick="updateFunctionSetting('${ePath}', '${eSig}', 'mode', 'normal', this)">
                                                     Normal
                                                 </label>
                                             </span>
                                             <span class="optimized-radio">
-                                                <label class="radio-label ${config.mode === Mode.FAIL ? 'selected' : ''}" 
-                                                       data-value="fail" 
-                                                       onclick="updateFunctionSetting('${contract.jsonPath}', '${signature}', 'mode', 'fail', this)">
+                                                <label class="radio-label ${config.mode === Mode.FAIL ? 'selected' : ''}"
+                                                       data-value="fail"
+                                                       onclick="updateFunctionSetting('${ePath}', '${eSig}', 'mode', 'fail', this)">
                                                     Fail
                                                 </label>
                                             </span>
                                             <span class="optimized-radio">
-                                                <label class="radio-label ${config.mode === Mode.CANARY ? 'selected' : ''}" 
-                                                       data-value="canary" 
-                                                       onclick="updateFunctionSetting('${contract.jsonPath}', '${signature}', 'mode', 'canary', this)">
+                                                <label class="radio-label ${config.mode === Mode.CANARY ? 'selected' : ''}"
+                                                       data-value="canary"
+                                                       onclick="updateFunctionSetting('${ePath}', '${eSig}', 'mode', 'canary', this)">
                                                     Canary
                                                 </label>
                                             </span>
                                             <span class="optimized-radio">
-                                                <label class="radio-label ${config.mode === Mode.CATCH ? 'selected' : ''}" 
-                                                       data-value="catch" 
-                                                       onclick="updateFunctionSetting('${contract.jsonPath}', '${signature}', 'mode', 'catch', this)">
+                                                <label class="radio-label ${config.mode === Mode.CATCH ? 'selected' : ''}"
+                                                       data-value="catch"
+                                                       onclick="updateFunctionSetting('${ePath}', '${eSig}', 'mode', 'catch', this)">
                                                     Catch
                                                 </label>
                                             </span>
                                         </div>
                                         <div class="optimized-radio-group" data-type="actor">
                                             <span class="optimized-radio">
-                                                <label class="radio-label ${config.actor === Actor.ACTOR ? 'selected' : ''}" 
-                                                       data-value="actor" 
-                                                       onclick="updateFunctionSetting('${contract.jsonPath}', '${signature}', 'actor', 'actor', this)">
+                                                <label class="radio-label ${config.actor === Actor.ACTOR ? 'selected' : ''}"
+                                                       data-value="actor"
+                                                       onclick="updateFunctionSetting('${ePath}', '${eSig}', 'actor', 'actor', this)">
                                                     Actor
                                                 </label>
                                             </span>
                                             <span class="optimized-radio">
-                                                <label class="radio-label ${config.actor === Actor.ADMIN ? 'selected' : ''}" 
-                                                       data-value="admin" 
-                                                       onclick="updateFunctionSetting('${contract.jsonPath}', '${signature}', 'actor', 'admin', this)">
+                                                <label class="radio-label ${config.actor === Actor.ADMIN ? 'selected' : ''}"
+                                                       data-value="admin"
+                                                       onclick="updateFunctionSetting('${ePath}', '${eSig}', 'actor', 'admin', this)">
                                                     Admin
                                                 </label>
                                             </span>

--- a/src/reconMainView.ts
+++ b/src/reconMainView.ts
@@ -404,7 +404,7 @@ export class ReconMainViewProvider implements vscode.WebviewViewProvider {
                     
                     document.getElementById('medusa-test-limit')?.addEventListener('change', (e) => {
                         const value = parseInt(e.target.value, 10);
-                        if (!isNaN(value) && value >= 1) {
+                        if (!isNaN(value) && value >= 0) {
                             vscode.postMessage({
                                 type: 'updateMedusaTestLimit',
                                 value: value
@@ -698,7 +698,7 @@ export class ReconMainViewProvider implements vscode.WebviewViewProvider {
                             id="medusa-test-limit"
                             type="number"
                             value="${medusaTestLimit}"
-                            min="1"
+                            min="0"
                         ></vscode-text-field>
                     </div>
                     <div class="setting-group">


### PR DESCRIPTION
## Summary

- Traditionally safety checks & security under weird situations
- Some UX fixes 

## Fix changes

### Primary
- **Command injection via `target` param** (fuzzingCommands.ts) — refactored from `spawn(commandString, {shell:true})` to `spawn(binary, argsArray)`. Each argument is a separate argv element, never shell-parsed.
- **Command injection via `buildArgs`** (buildCommands.ts) — same `spawn` with args array fix
- **XSS in reconContractsView.ts** — added `escapeHtmlAttr()` to all 26+ template interpolations (contract metadata in onclick/onchange/data attributes)
- **DOM XSS via fuzzyMatch + innerHTML** — escape text segments before wrapping in highlight spans
- **XSS in dynamic innerHTML template** — escape contractName/signature before onclick interpolation
- **Shell expansion in replay path** — single-quote escaping for replay file paths

### Secondary
- **CSP on coverage report webviews** — `default-src 'none'` blocks scripts in loaded HTML
- **HTML escaping in coverage stats** — `escapeHtml()` on all interpolated values (data.path, functionName, untouchedContent)
- **Unescaped file.path in coverage list** — `escapeHtml()` on onclick handler interpolations
- **Canary mode wrong identifier** — `contract.jsonPath` instead of `contract.name`
- **Missing event parameter** — `openExternal`/`showCoverageStats` now receive `event`
- **Medusa test limit min=0** — aligns UI with package.json schema

### Minor
- **enableScripts:true on report panels** — set to `false` (CSP already blocks scripts)
- **CSS var() typo** — removed space in `var (--vscode-editor-font-family)`
- **.DS_Store in .gitignore**
- **Single-quote escaping in coverageView escapeHtml** — caught by runtime tests

## Verification

- `tsc --noEmit` — 0 errors
- `eslint src` — 0 errors
- `vsce package` — builds successfully (186.98KB)
- 23 security property tests — all pass
- 21 user flow tests — all pass (normal Solidity names/paths/signatures pass through escaping unchanged)

## Test plan

- [ ] Open extension in VS Code, verify contracts view renders normally
- [ ] Run `recon fuzz` with default settings, verify it starts
- [ ] Run `forge build` with custom `buildArgs`, verify it works
- [ ] Search contracts in sidebar, verify highlight works
- [ ] Open coverage report, verify it displays (no scripts needed)
- [ ] Click coverage stats, verify stats panel works
- [ ] Set medusa test-limit to 0, verify it accepts