### PR TITLE
fix: harden Windows PATH and coverage path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Recon can be configured through VS Code settings:
 ### Common Issues
 
 - **Fuzzer not found**: Ensure Echidna/Medusa are installed and in your PATH
+- **Fuzzer not found on Windows**: Add Foundry and fuzzer install directories to `terminal.integrated.env.windows.PATH` or the system PATH. Windows PATH entries must be separated with semicolons (`;`), and coverage files should be selected from the Coverage Reports view so Windows paths are passed through the extension safely.
 - **Compilation errors**: Run `forge build` manually to identify issues
 - **No contracts showing**: Check if `out/` directory exists with compiled contracts
 - Halmos log parser may have a few bugs

--- a/src/coverageView.ts
+++ b/src/coverageView.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { findSrcDirectory, getFoundryConfigPath } from './utils';
 import { CoverageFile, FuzzerTool } from './types';
 import { readCoverageFileAndProcess } from 'echidna-coverage-parser';
+import { escapeHtmlAttribute } from './platformPaths';
 
 export class CoverageViewProvider implements vscode.WebviewViewProvider {
     private _view?: vscode.WebviewView;
@@ -685,7 +686,7 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
             <body>
                 <div class="coverage-list">
                     ${coverageFiles.map(file => `
-                        <div class="coverage-item">
+                        <div class="coverage-item" data-coverage-path="${escapeHtmlAttribute(file.path)}">
                             <div class="coverage-left">
                                 <i class="codicon codicon-file"></i>
                                 <div class="coverage-info">
@@ -697,9 +698,9 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
                             </div>
                             <div class="coverage-actions">
                                 ${file.type === FuzzerTool.ECHIDNA ? `
-                                    <i class="codicon codicon-checklist coverage-stats" onclick="showCoverageStats('${file.path}')" title="Coverage Stats"></i>
+                                    <i class="codicon codicon-checklist coverage-stats" data-action="stats" title="Coverage Stats"></i>
                                 ` : ''}
-                                <i class="codicon codicon-link-external external-link" onclick="openExternal('${file.path}')" title="Open in browser"></i>
+                                <i class="codicon codicon-link-external external-link" data-action="open" title="Open in browser"></i>
                             </div>
                         </div>
                     `).join('')}
@@ -714,8 +715,19 @@ export class CoverageViewProvider implements vscode.WebviewViewProvider {
                                 document.querySelectorAll('.coverage-item').forEach(i => 
                                     i.classList.remove('selected'));
                                 this.classList.add('selected');
-                                const path = this.querySelector('.coverage-actions').lastElementChild.getAttribute('onclick').match(/'([^']+)'/)[1];
-                                selectCoverage(path);
+                                selectCoverage(this.dataset.coveragePath);
+                            }
+                        });
+                    });
+
+                    document.querySelectorAll('.coverage-actions [data-action]').forEach(action => {
+                        action.addEventListener('click', function(event) {
+                            event.stopPropagation();
+                            const path = this.closest('.coverage-item').dataset.coveragePath;
+                            if (this.dataset.action === 'stats') {
+                                showCoverageStats(path);
+                            } else {
+                                openExternal(path);
                             }
                         });
                     });

--- a/src/platformPaths.ts
+++ b/src/platformPaths.ts
@@ -1,0 +1,39 @@
+import * as path from 'path';
+
+export function getPathDelimiter(platform: NodeJS.Platform = process.platform): string {
+    return platform === 'win32' ? ';' : ':';
+}
+
+export function combinePathSources(
+    userPath: string,
+    shellPath: string,
+    defaultPath: string,
+    platform: NodeJS.Platform = process.platform
+): string {
+    const delimiter = getPathDelimiter(platform);
+    const fragments = platform === 'win32'
+        ? [...userPath.split(delimiter), ...defaultPath.split(delimiter)]
+        : [...userPath.split(delimiter), ...shellPath.split(delimiter), ...defaultPath.split(delimiter)];
+
+    return Array.from(new Set(fragments.filter(Boolean))).join(delimiter);
+}
+
+export function normalizeCoveragePath(filePath: string): string {
+    return filePath.split(path.win32.sep).join(path.posix.sep);
+}
+
+export function isSourceOrReconCoveragePath(filePath: string, sourceDirectory: string): boolean {
+    const normalizedPath = normalizeCoveragePath(filePath);
+    const normalizedSourceDirectory = normalizeCoveragePath(sourceDirectory).replace(/^\/+|\/+$/g, '');
+
+    return normalizedPath.startsWith(`${normalizedSourceDirectory}/`) || normalizedPath.includes('/recon');
+}
+
+export function escapeHtmlAttribute(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}

--- a/src/test/platformPaths.test.ts
+++ b/src/test/platformPaths.test.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert';
+import {
+    combinePathSources,
+    escapeHtmlAttribute,
+    isSourceOrReconCoveragePath,
+    normalizeCoveragePath
+} from '../platformPaths';
+
+describe('platform path handling', () => {
+    it('preserves Windows drive letters when combining PATH fragments', () => {
+        const combined = combinePathSources(
+            'C:\\Users\\alice\\.foundry\\bin',
+            '/ignored/shell/path',
+            'C:\\Windows\\System32;C:\\Program Files\\Git\\cmd',
+            'win32'
+        );
+
+        assert.strictEqual(
+            combined,
+            'C:\\Users\\alice\\.foundry\\bin;C:\\Windows\\System32;C:\\Program Files\\Git\\cmd'
+        );
+    });
+
+    it('uses POSIX shell PATH as an extra source outside Windows', () => {
+        const combined = combinePathSources('/user/bin:/shared/bin', '/shell/bin:/shared/bin', '/default/bin', 'linux');
+
+        assert.strictEqual(combined, '/user/bin:/shared/bin:/shell/bin:/default/bin');
+    });
+
+    it('normalizes Windows coverage paths before source/recon filtering', () => {
+        assert.strictEqual(normalizeCoveragePath('src\\Counter.sol'), 'src/Counter.sol');
+        assert.strictEqual(isSourceOrReconCoveragePath('src\\Counter.sol', 'src'), true);
+        assert.strictEqual(isSourceOrReconCoveragePath('test\\recon\\CryticToFoundry.sol', 'src'), true);
+        assert.strictEqual(isSourceOrReconCoveragePath('lib\\forge-std\\Test.sol', 'src'), false);
+    });
+
+    it('escapes Windows paths safely for webview data attributes', () => {
+        assert.strictEqual(
+            escapeHtmlAttribute('C:\\Users\\alice\\repo\\echidna\\covered.1.lcov'),
+            'C:\\Users\\alice\\repo\\echidna\\covered.1.lcov'
+        );
+        assert.strictEqual(escapeHtmlAttribute('C:\\repo\\a"&<>\'.lcov'), 'C:\\repo\\a&quot;&amp;&lt;&gt;&#39;.lcov');
+    });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import { JSDOM } from 'jsdom';
 import { FileBlock } from './types';
 import { execSync } from 'child_process';
+import { combinePathSources, isSourceOrReconCoveragePath } from './platformPaths';
 
 export function getFoundryConfigPath(workspaceRoot: string): string {
     const configPath = vscode.workspace.getConfiguration('recon').get<string>('foundryConfigPath', 'foundry.toml');
@@ -159,16 +160,9 @@ export async function cleanupEchidnaCoverageReport(workspaceRoot: string, conten
     const foundryRoot = path.dirname(foundryConfigPath);
 
     // Filter blocks based on path conditions
-    const filteredBlocks = fileBlocks.filter(block => {
-        const relativePath = path.relative(foundryRoot, block.path);
-        if (relativePath.startsWith(`${srcDirectory}/`)) {
-            return true;
-        }
-        if (relativePath.includes('/recon')) {
-            return true;
-        }
-        return false;
-    });
+    const filteredBlocks = fileBlocks.filter(block =>
+        isSourceOrReconCoveragePath(path.relative(foundryRoot, block.path), srcDirectory)
+    );
 
     // Rebuild HTML with proper structure
     const cleanedHtml = `<!DOCTYPE html>
@@ -197,7 +191,7 @@ export async function cleanupMedusaCoverageReport(content: string): Promise<stri
         const sourceDivs = document.querySelectorAll('div.source-file');
         sourceDivs.forEach(div => {
             const filePath = div.getAttribute('data-file-path') || '';
-            const shouldRemove = !(filePath.startsWith(`${srcDirectory}/`) || filePath.includes('/recon'));
+            const shouldRemove = !isSourceOrReconCoveragePath(filePath, srcDirectory);
             if (shouldRemove) {
                 div.remove();
             }
@@ -222,7 +216,7 @@ export async function cleanupMedusaCoverageReport(content: string): Promise<stri
             const containerDiv = button.nextElementSibling as HTMLElement;
 
             // Check if we should keep this entry
-            const shouldKeep = relativePath.startsWith(`${srcDirectory}/`) || relativePath.includes('/recon');
+            const shouldKeep = isSourceOrReconCoveragePath(relativePath, srcDirectory);
 
             if (!shouldKeep) {
                 // Remove both button and container
@@ -276,15 +270,7 @@ export function getEnvironmentPath(): string {
         } catch (e) {
             console.warn('Failed to get shell PATH:', e);
         }
-    } else {
-        return userPath ? `${userPath}:${process.env.PATH}` : process.env.PATH || '';
     }
 
-    const combined = new Set([
-        ...userPath.split(':'),
-        ...shellPath.split(':'),
-        ...defaultPath.split(':'),
-    ].filter(Boolean));
-
-    return Array.from(combined).join(':');
+    return combinePathSources(userPath, shellPath, defaultPath);
 }


### PR DESCRIPTION
Refs #62.

Summary:
- Merge Windows PATH values using the platform delimiter instead of POSIX-only separators.
- Normalize/quote coverage paths before passing them into the webview.
- Add regression coverage for Windows PATH merging and coverage path filtering.

Validation:
- npm run compile
- npm run lint
- npx mocha out/test/platformPaths.test.js
