### PR TITLE
Fix Windows path handling

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import { execSync } from 'child_process';
 
 export function getFoundryConfigPath(workspaceRoot: string): string {
     const configPath = vscode.workspace.getConfiguration('recon').get<string>('foundryConfigPath', 'foundry.toml');
-    return path.join(workspaceRoot, configPath);
+    return path.isAbsolute(configPath) ? configPath : path.join(workspaceRoot, configPath);
 }
 
 export async function findOutputDirectory(workspaceRoot: string): Promise<string> {
@@ -19,7 +19,7 @@ export async function findOutputDirectory(workspaceRoot: string): Promise<string
         if (match) {
             // If path is absolute, use it directly; otherwise, make it relative to foundry.toml location
             const outPath = match[1];
-            return path.join(path.dirname(foundryConfigPath), outPath);
+            return path.isAbsolute(outPath) ? outPath : path.join(path.dirname(foundryConfigPath), outPath);
         }
         return path.join(path.dirname(foundryConfigPath), 'out');
     } catch {
@@ -126,6 +126,25 @@ export const getUid = () => {
     return Math.random().toString(36).substring(2, 6);
 };
 
+function toPosixPath(filePath: string): string {
+    return filePath.replace(/\\/g, '/');
+}
+
+function trimSlashes(filePath: string): string {
+    return toPosixPath(filePath).replace(/^\/+|\/+$/g, '');
+}
+
+function isSourceOrReconPath(filePath: string): boolean {
+    const normalizedPath = trimSlashes(filePath);
+    const normalizedSrcDirectory = trimSlashes(srcDirectory);
+
+    return normalizedPath === normalizedSrcDirectory ||
+        normalizedPath.startsWith(`${normalizedSrcDirectory}/`) ||
+        normalizedPath.includes(`/${normalizedSrcDirectory}/`) ||
+        normalizedPath.endsWith(`/${normalizedSrcDirectory}`) ||
+        normalizedPath.split('/').includes('recon');
+}
+
 
 export async function cleanupEchidnaCoverageReport(workspaceRoot: string, content: string): Promise<string> {
     const dom = new JSDOM(content, {
@@ -161,13 +180,7 @@ export async function cleanupEchidnaCoverageReport(workspaceRoot: string, conten
     // Filter blocks based on path conditions
     const filteredBlocks = fileBlocks.filter(block => {
         const relativePath = path.relative(foundryRoot, block.path);
-        if (relativePath.startsWith(`${srcDirectory}/`)) {
-            return true;
-        }
-        if (relativePath.includes('/recon')) {
-            return true;
-        }
-        return false;
+        return isSourceOrReconPath(relativePath);
     });
 
     // Rebuild HTML with proper structure
@@ -197,7 +210,7 @@ export async function cleanupMedusaCoverageReport(content: string): Promise<stri
         const sourceDivs = document.querySelectorAll('div.source-file');
         sourceDivs.forEach(div => {
             const filePath = div.getAttribute('data-file-path') || '';
-            const shouldRemove = !(filePath.startsWith(`${srcDirectory}/`) || filePath.includes('/recon'));
+            const shouldRemove = !isSourceOrReconPath(filePath);
             if (shouldRemove) {
                 div.remove();
             }
@@ -222,7 +235,7 @@ export async function cleanupMedusaCoverageReport(content: string): Promise<stri
             const containerDiv = button.nextElementSibling as HTMLElement;
 
             // Check if we should keep this entry
-            const shouldKeep = relativePath.startsWith(`${srcDirectory}/`) || relativePath.includes('/recon');
+            const shouldKeep = isSourceOrReconPath(relativePath);
 
             if (!shouldKeep) {
                 // Remove both button and container
@@ -265,7 +278,9 @@ export function getEnvironmentPath(): string {
                 ? 'terminal.integrated.env.osx'
                 : 'terminal.integrated.env.linux';
 
-    const userPath = vscode.workspace.getConfiguration().get<{ [key: string]: string }>(platformKey)?.PATH || '';
+    const terminalEnv = vscode.workspace.getConfiguration().get<Record<string, string | undefined>>(platformKey) || {};
+    const userPath = terminalEnv.PATH || terminalEnv.Path || terminalEnv.path || '';
+    const splitPath = (value: string) => value.split(path.delimiter).filter(Boolean);
 
     let shellPath = '';
     if (process.platform !== 'win32') {
@@ -276,15 +291,13 @@ export function getEnvironmentPath(): string {
         } catch (e) {
             console.warn('Failed to get shell PATH:', e);
         }
-    } else {
-        return userPath ? `${userPath}:${process.env.PATH}` : process.env.PATH || '';
     }
 
     const combined = new Set([
-        ...userPath.split(':'),
-        ...shellPath.split(':'),
-        ...defaultPath.split(':'),
+        ...splitPath(userPath),
+        ...splitPath(shellPath),
+        ...splitPath(defaultPath),
     ].filter(Boolean));
 
-    return Array.from(combined).join(':');
+    return Array.from(combined).join(path.delimiter);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import { execSync } from 'child_process';
 
 export function getFoundryConfigPath(workspaceRoot: string): string {
     const configPath = vscode.workspace.getConfiguration('recon').get<string>('foundryConfigPath', 'foundry.toml');
-    return path.join(workspaceRoot, configPath);
+    return path.isAbsolute(configPath) ? configPath : path.join(workspaceRoot, configPath);
 }
 
 export async function findOutputDirectory(workspaceRoot: string): Promise<string> {
@@ -19,7 +19,7 @@ export async function findOutputDirectory(workspaceRoot: string): Promise<string
         if (match) {
             // If path is absolute, use it directly; otherwise, make it relative to foundry.toml location
             const outPath = match[1];
-            return path.join(path.dirname(foundryConfigPath), outPath);
+            return path.isAbsolute(outPath) ? outPath : path.join(path.dirname(foundryConfigPath), outPath);
         }
         return path.join(path.dirname(foundryConfigPath), 'out');
     } catch {
@@ -126,6 +126,25 @@ export const getUid = () => {
     return Math.random().toString(36).substring(2, 6);
 };
 
+function toPosixPath(filePath: string): string {
+    return filePath.replace(/\\/g, '/');
+}
+
+function trimSlashes(filePath: string): string {
+    return toPosixPath(filePath).replace(/^\/+|\/+$/g, '');
+}
+
+function isSourceOrReconPath(filePath: string): boolean {
+    const normalizedPath = trimSlashes(filePath);
+    const normalizedSrcDirectory = trimSlashes(srcDirectory);
+
+    return normalizedPath === normalizedSrcDirectory ||
+        normalizedPath.startsWith(`${normalizedSrcDirectory}/`) ||
+        normalizedPath.includes(`/${normalizedSrcDirectory}/`) ||
+        normalizedPath.endsWith(`/${normalizedSrcDirectory}`) ||
+        normalizedPath.split('/').includes('recon');
+}
+
 
 export async function cleanupEchidnaCoverageReport(workspaceRoot: string, content: string): Promise<string> {
     const dom = new JSDOM(content, {
@@ -161,13 +180,7 @@ export async function cleanupEchidnaCoverageReport(workspaceRoot: string, conten
     // Filter blocks based on path conditions
     const filteredBlocks = fileBlocks.filter(block => {
         const relativePath = path.relative(foundryRoot, block.path);
-        if (relativePath.startsWith(`${srcDirectory}/`)) {
-            return true;
-        }
-        if (relativePath.includes('/recon')) {
-            return true;
-        }
-        return false;
+        return isSourceOrReconPath(relativePath);
     });
 
     // Rebuild HTML with proper structure
@@ -197,7 +210,7 @@ export async function cleanupMedusaCoverageReport(content: string): Promise<stri
         const sourceDivs = document.querySelectorAll('div.source-file');
         sourceDivs.forEach(div => {
             const filePath = div.getAttribute('data-file-path') || '';
-            const shouldRemove = !(filePath.startsWith(`${srcDirectory}/`) || filePath.includes('/recon'));
+            const shouldRemove = !isSourceOrReconPath(filePath);
             if (shouldRemove) {
                 div.remove();
             }
@@ -222,7 +235,7 @@ export async function cleanupMedusaCoverageReport(content: string): Promise<stri
             const containerDiv = button.nextElementSibling as HTMLElement;
 
             // Check if we should keep this entry
-            const shouldKeep = relativePath.startsWith(`${srcDirectory}/`) || relativePath.includes('/recon');
+            const shouldKeep = isSourceOrReconPath(relativePath);
 
             if (!shouldKeep) {
                 // Remove both button and container


### PR DESCRIPTION
## Summary
- Respect absolute `recon.foundryConfigPath` and Foundry `out` paths instead of joining them back under the workspace.
- Normalize coverage report paths before filtering for source and `recon` files, so Windows backslash paths are handled correctly.
- Build the child-process `PATH` with `path.delimiter` and support Windows `PATH`/`Path` casing from VS Code terminal env settings.

Addresses part of #62.

## Testing
- `npm ci` (runs `prepare` -> `tsc -p ./`)
- `npm run compile`
- `npm run lint` (passes with existing warnings in `src/argus/slot.ts` and `src/argus/types.ts`)
